### PR TITLE
order-by-datetime

### DIFF
--- a/lib/components/indoorenv/lambda/dataReader/index.js
+++ b/lib/components/indoorenv/lambda/dataReader/index.js
@@ -26,7 +26,8 @@ exports.handler = async (event) => {
                             AND dt between '${event.startTime.substring(0,4)}-${event.startTime.substring(5,7)}-${event.startTime.substring(8,10)}-${event.startTime.substring(11,13)}' 
                                 AND '${event.endTime.substring(0,4)}-${event.endTime.substring(5,7)}-${event.endTime.substring(8,10)}-${event.endTime.substring(11,13)}' 
                             AND id='${event.entityId}' 
-                            AND json_extract_scalar(dateObserved, '$.value') between '${event.startTime}' and  '${event.endTime}'`,
+                            AND json_extract_scalar(dateObserved, '$.value') between '${event.startTime}' and  '${event.endTime}'
+                            ORDER BY dateObserved DESC`,
             QueryExecutionContext: {
                 Database: ATHENA_DB
             },


### PR DESCRIPTION
Forces query to return values in date time order

Twinmaker scene viewer flashes incorrect tag icon before selecting latest state

*Description of changes:*

Added ORDER BY statement to component data-reader lamda function

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
